### PR TITLE
feat(jvm): Add functionality to InstructionList.

### DIFF
--- a/src/jvm/code/method_body.rs
+++ b/src/jvm/code/method_body.rs
@@ -123,12 +123,27 @@ impl<I> InstructionList<I> {
         self.0.first_key_value()
     }
 
+    /// Returns the last instruction in the list.
+    #[must_use]
+    pub fn exit_point(&self) -> Option<(&ProgramCounter, &I)> {
+        self.0.last_key_value()
+    }
+
     /// Returns the program counter of the next instruction after the given one.
     #[must_use]
     pub fn next_pc_of(&self, pc: &ProgramCounter) -> Option<ProgramCounter> {
         self.0
             .range((Bound::Excluded(pc), Bound::Unbounded))
             .next()
+            .map(|(k, _)| *k)
+    }
+
+    /// Returns the program counter of the previous instruction before the given one.
+    #[must_use]
+    pub fn prev_pc_of(&self, pc: &ProgramCounter) -> Option<ProgramCounter> {
+        self.0
+            .range((Bound::Unbounded, Bound::Excluded(pc)))
+            .next_back()
             .map(|(k, _)| *k)
     }
 

--- a/src/jvm/code/method_body.rs
+++ b/src/jvm/code/method_body.rs
@@ -177,7 +177,10 @@ impl InstructionList<RawInstruction> {
 
 #[cfg(test)]
 mod test {
-    use crate::jvm::code::{Instruction, InstructionList};
+    use crate::{
+        ir::MokaInstruction,
+        jvm::code::{Instruction, InstructionList},
+    };
 
     use super::MethodBody;
     use Instruction::*;
@@ -201,6 +204,42 @@ mod test {
             free_attributes: vec![],
         };
         assert_eq!(Some(&IConst0), body.instruction_at(1.into()));
+    }
+
+    #[test]
+    fn last_instruction() {
+        let instruction_list = InstructionList::from([
+            (0.into(), MokaInstruction::Nop),
+            (
+                1.into(),
+                MokaInstruction::Jump {
+                    condition: None,
+                    target: 1.into(),
+                },
+            ),
+            (2.into(), MokaInstruction::Return(None)),
+        ]);
+        assert_eq!(
+            Some((&2.into(), &MokaInstruction::Return(None))),
+            instruction_list.last_instruction()
+        );
+    }
+
+    #[test]
+    fn previous_pc() {
+        let instruction_list = InstructionList::from([
+            (0.into(), MokaInstruction::Nop),
+            (
+                1.into(),
+                MokaInstruction::Jump {
+                    condition: None,
+                    target: 1.into(),
+                },
+            ),
+            (2.into(), MokaInstruction::Return(None)),
+        ]);
+        assert_eq!(Some(0.into()), instruction_list.prev_pc_of(&1.into()));
+        assert_eq!(None, instruction_list.prev_pc_of(&0.into()));
     }
 }
 

--- a/src/jvm/code/method_body.rs
+++ b/src/jvm/code/method_body.rs
@@ -125,7 +125,7 @@ impl<I> InstructionList<I> {
 
     /// Returns the last instruction in the list.
     #[must_use]
-    pub fn exit_point(&self) -> Option<(&ProgramCounter, &I)> {
+    pub fn last_instruction(&self) -> Option<(&ProgramCounter, &I)> {
         self.0.last_key_value()
     }
 


### PR DESCRIPTION
- Add `exit_point` to return the last instruction in the list.
- Add `prev_pc_of` to return the program counter of the previous instruction before the given one.