### PR TITLE
feat(jvm): merge high-level instructions

### DIFF
--- a/src/jvm/code/instruction.rs
+++ b/src/jvm/code/instruction.rs
@@ -246,6 +246,7 @@ pub enum Instruction {
     MonitorExit = 0xc3,
 
     // Extended
+    #[deprecated(note = "Use the inner instruction instead")]
     Wide(WideInstruction) = 0xc4,
     MultiANewArray(FieldType, u8) = 0xc5,
     IfNull(ProgramCounter) = 0xc6,


### PR DESCRIPTION
High-level JVM instructions do no need `Wide`. Instead, wide instructions should be generated when the index is greater than `u8`.