### PR TITLE
feat(jvm): Return DoubleEndedIterator for InstructionList.

### DIFF
--- a/src/jvm/code/method_body.rs
+++ b/src/jvm/code/method_body.rs
@@ -89,7 +89,9 @@ impl<'i, I> IntoIterator for &'i InstructionList<I> {
 impl<I> InstructionList<I> {
     /// Creates an iterator over the instructions.
     #[must_use]
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (&ProgramCounter, &I)> {
+    pub fn iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (&ProgramCounter, &I)> + ExactSizeIterator {
         self.into_iter()
     }
 }

--- a/src/jvm/code/method_body.rs
+++ b/src/jvm/code/method_body.rs
@@ -88,7 +88,8 @@ impl<'i, I> IntoIterator for &'i InstructionList<I> {
 
 impl<I> InstructionList<I> {
     /// Creates an iterator over the instructions.
-    pub fn iter(&self) -> impl Iterator<Item = (&ProgramCounter, &I)> {
+    #[must_use]
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (&ProgramCounter, &I)> {
         self.into_iter()
     }
 }


### PR DESCRIPTION
A small quality of life for `InstructionList`. Removes the need for unnecessary clones in some use cases (for using `.rev()` on borrowed instances).

Doesn't affect existing code, however I'm not used to API building, so feel free to shoot this down. 😄