### PR TITLE
Enable Error Annotation for CI Errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ env:
   CARGO_TERM_COLOR: always
   JAVA_VERSION: 23
 
+permissions:
+  checks: write
+
 jobs:
   style_rustfmt:
     name: Style / rustfmt
@@ -65,7 +68,11 @@ jobs:
       - run: cargo check --all-targets --all-features --verbose
         name: Cargo check
       - name: Run clippy
-        run: cargo clippy --no-deps --all-targets --all-features -- -D warnings
+        uses: auguwu/clippy-action@1.4.0
+        with:
+          check-args: --all-targets --all-features --verbose
+          args: -D warnings
+          token: ${{secrets.GITHUB_TOKEN}}
 
   unit_test:
     name: Test / unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,18 +38,13 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: corretto
       - uses: actions/checkout@v4
         name: Checkout source code
       - name: Check code formatting with rustfmt
-        run: cargo fmt --check
+        uses: actions-rust-lang/rustfmt@v1
 
   style_clippy_check:
-    name: Style / clippy & check
+    name: Style / clippy
     runs-on: ubuntu-latest
     steps:
       - name: Setup Rust
@@ -65,8 +60,6 @@ jobs:
         name: Checkout source code
       - name: Restore Rust Build Cache
         uses: Leafwing-Studios/cargo-cache@v2
-      - run: cargo check --all-targets --all-features --verbose
-        name: Cargo check
       - name: Run clippy
         uses: auguwu/clippy-action@1.4.0
         with:

--- a/src/jvm/class_loader/mod.rs
+++ b/src/jvm/class_loader/mod.rs
@@ -8,7 +8,7 @@ use super::{Class, ClassLoader};
 
 /// An error that can occur while loading a class.
 #[derive(thiserror::Error, Debug)]
-pub enum    Error {
+pub enum Error {
     /// The class could not be found.
     #[error("Class not found")]
     NotFound,
@@ -38,7 +38,6 @@ where
     <T as Deref>::Target: ClassPath,
 {
     fn find_class(&self, binary_name: &str) -> Result<Class, Error> {
-        let x = 10;
         self.deref().find_class(binary_name)
     }
 }

--- a/src/jvm/class_loader/mod.rs
+++ b/src/jvm/class_loader/mod.rs
@@ -8,7 +8,7 @@ use super::{Class, ClassLoader};
 
 /// An error that can occur while loading a class.
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+pub enum    Error {
     /// The class could not be found.
     #[error("Class not found")]
     NotFound,
@@ -38,6 +38,7 @@ where
     <T as Deref>::Target: ClassPath,
 {
     fn find_class(&self, binary_name: &str) -> Result<Class, Error> {
+        let x = 10;
         self.deref().find_class(binary_name)
     }
 }


### PR DESCRIPTION
Closes #21 

- [x] cargo fmt
- [x] ~cargo check~
- [x] Clippy
- [ ] Build
- [ ] Test
- [ ] Doc

---

cargo check are removed since clippy does more thing than it.