### PR TITLE
Better Error APIs

### DIFF
--- a/src/jvm/bytecode/attribute.rs
+++ b/src/jvm/bytecode/attribute.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use num_traits::ToBytes;
 
 use super::{
-    FromReader, ParsingContext, ParseError, ToWriter,
+    FromReader, ParseError, ParsingContext, ToWriter,
     code::{LocalVariableDescAttr, LocalVariableTypeAttr},
     errors::GenerationError,
     jvm_element_parser::ClassElement,

--- a/src/jvm/bytecode/attribute.rs
+++ b/src/jvm/bytecode/attribute.rs
@@ -245,7 +245,7 @@ impl ClassElement for Attribute {
         if reader.is_empty() {
             Ok(result)
         } else {
-            Err(ParsingError::IO(io::Error::new(
+            Err(ParsingError::from(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Extra data at the end of the attribute",
             )))

--- a/src/jvm/bytecode/class_file.rs
+++ b/src/jvm/bytecode/class_file.rs
@@ -46,7 +46,7 @@ const JAVA_CLASS_MAGIC: u32 = 0xCAFE_BABE;
 impl Class {
     /// Parses a class file from the given reader.
     /// # Errors
-    /// See [`ParsingError`] for more information.
+    /// See [`ParseError`] for more information.
     /// # Example
     /// ```no_run
     /// use mokapot::jvm::Class;
@@ -67,7 +67,7 @@ impl Class {
 
     /// Writes the class file to the given writer.
     /// # Errors
-    /// See [`ToWriterError`] for more information.
+    /// See [`GenerationError`] for more information.
     pub fn to_writer<W>(self, writer: &mut W) -> Result<(), GenerationError>
     where
         W: Write + ?Sized,

--- a/src/jvm/bytecode/class_file.rs
+++ b/src/jvm/bytecode/class_file.rs
@@ -3,7 +3,7 @@ use std::io::{self, Read, Write};
 use itertools::Itertools;
 
 use super::{
-    FromReader, ParsingContext, ParseError, ToWriter,
+    FromReader, ParseError, ParsingContext, ToWriter,
     attribute::{Attribute, AttributeInfo},
     errors::GenerationError,
     field_info::FieldInfo,

--- a/src/jvm/bytecode/code/instruction_impl.rs
+++ b/src/jvm/bytecode/code/instruction_impl.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use crate::{
     jvm::{
         bytecode::{
-            ParsingContext, ParseError,
+            ParseError, ParsingContext,
             errors::{GenerationError, ParsingErrorContext},
             jvm_element_parser::ClassElement,
         },

--- a/src/jvm/bytecode/code/instruction_impl.rs
+++ b/src/jvm/bytecode/code/instruction_impl.rs
@@ -469,7 +469,7 @@ impl Instruction {
     /// Lower the instruction into a raw instruction.
     ///
     /// # Errors
-    /// See [`ToWriterError`] for details.
+    /// See [`GenerationError`] for details.
     #[allow(clippy::too_many_lines)]
     pub fn into_raw_instruction(
         self,

--- a/src/jvm/bytecode/code/mod.rs
+++ b/src/jvm/bytecode/code/mod.rs
@@ -11,7 +11,7 @@ use std::{
 use itertools::Itertools;
 
 use super::{
-    FromReader, ParsingContext, ParseError, ToWriter,
+    FromReader, ParseError, ParsingContext, ToWriter,
     attribute::Attribute,
     errors::{GenerationError, ParsingErrorContext},
     jvm_element_parser::ClassElement,

--- a/src/jvm/bytecode/code/mod.rs
+++ b/src/jvm/bytecode/code/mod.rs
@@ -11,12 +11,12 @@ use std::{
 use itertools::Itertools;
 
 use super::{
-    FromReader, ParseError, ParsingContext, ToWriter,
+    FromBytecode, ParseError, ParsingContext, ToBytecode,
     attribute::Attribute,
     errors::{GenerationError, ParsingErrorContext},
     jvm_element_parser::ClassElement,
     raw_attributes::{self, Code},
-    reader_utils::ValueReaderExt,
+    reader_utils::BytecodeReader,
 };
 use crate::{
     jvm::{
@@ -57,10 +57,10 @@ impl ClassElement for LineNumberTableEntry {
     }
 }
 
-impl FromReader for LineNumberTableEntry {
+impl FromBytecode for LineNumberTableEntry {
     fn from_reader<R: Read + ?Sized>(reader: &mut R) -> io::Result<Self> {
-        let start_pc = reader.read_value()?;
-        let line_number = reader.read_value()?;
+        let start_pc = reader.decode_value()?;
+        let line_number = reader.decode_value()?;
         Ok(LineNumberTableEntry {
             start_pc,
             line_number,
@@ -68,7 +68,7 @@ impl FromReader for LineNumberTableEntry {
     }
 }
 
-impl ToWriter for LineNumberTableEntry {
+impl ToBytecode for LineNumberTableEntry {
     fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&u16::from(self.start_pc).to_be_bytes())?;
         writer.write_all(&self.line_number.to_be_bytes())?;
@@ -208,7 +208,7 @@ impl ClassElement for LocalVariableTypeAttr {
     }
 }
 
-impl ToWriter for ProgramCounter {
+impl ToBytecode for ProgramCounter {
     fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         let inner = u16::from(*self);
         writer.write_all(&inner.to_be_bytes())?;

--- a/src/jvm/bytecode/code/raw_instruction.rs
+++ b/src/jvm/bytecode/code/raw_instruction.rs
@@ -13,7 +13,7 @@ use crate::jvm::{
 impl InstructionList<RawInstruction> {
     /// Parses a list of [`RawInstruction`]s from the given bytes.
     /// # Errors
-    /// See [`ParsingError`] for more information.
+    /// See [`ParseError`] for more information.
     pub fn from_bytes(bytes: Vec<u8>) -> Result<InstructionList<RawInstruction>, ParseError> {
         let bytes = VecDeque::from(bytes);
         let mut reader = PositionTracker::new(bytes);
@@ -25,7 +25,7 @@ impl InstructionList<RawInstruction> {
 
     /// Writes a list of [`RawInstruction`]s to the given writer.
     /// # Errors
-    /// See [`ToWriterError`] for more information.
+    /// See [`GenerationError`] for more information.
     pub fn to_writer<W: io::Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         let mut writer = PositionTracker::new(writer);
 

--- a/src/jvm/bytecode/code/raw_instruction.rs
+++ b/src/jvm/bytecode/code/raw_instruction.rs
@@ -561,7 +561,7 @@ impl RawInstruction {
             },
             0x5f => Swap,
             0xc4 => {
-                let wide_opcode = reader.decode_value()?;
+                let wide_opcode: u8 = reader.decode_value()?;
                 let wide_insn = match wide_opcode {
                     0x15 => RawWideInstruction::ILoad {
                         index: reader.decode_value()?,

--- a/src/jvm/bytecode/code/raw_instruction.rs
+++ b/src/jvm/bytecode/code/raw_instruction.rs
@@ -699,8 +699,8 @@ impl RawInstruction {
             // Variable-length instructions require special handling
             TableSwitch { low, high, .. } => {
                 let padding = (4 - (u16::from(pc) + 1) % 4) % 4; // padding after opcode
-                let entries =
-                    u16::try_from(*high - *low + 1).map_err(|_| GenerationError::other("In"))?;
+                let entries = u16::try_from(*high - *low + 1)
+                    .map_err(|_| GenerationError::other("Invalid jump offset"))?;
                 1 + padding + 12 + (4 * entries) // opcode + padding + default,low,high + entries
             }
 

--- a/src/jvm/bytecode/code/stack_map.rs
+++ b/src/jvm/bytecode/code/stack_map.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 
 use crate::jvm::{
     bytecode::{
-        ParsingContext, ParsingError, errors::ToWriterError, jvm_element_parser::ClassElement,
+        ParsingContext, ParseError, errors::GenerationError, jvm_element_parser::ClassElement,
         raw_attributes,
     },
     class::ConstantPool,
@@ -12,7 +12,7 @@ use crate::jvm::{
 impl ClassElement for StackMapFrame {
     type Raw = raw_attributes::StackMapFrameInfo;
 
-    fn from_raw(raw: Self::Raw, ctx: &ParsingContext) -> Result<Self, ParsingError> {
+    fn from_raw(raw: Self::Raw, ctx: &ParsingContext) -> Result<Self, ParseError> {
         match raw {
             Self::Raw::SameFrame { frame_type } => Ok(Self::SameFrame {
                 offset_delta: u16::from(frame_type),
@@ -73,7 +73,7 @@ impl ClassElement for StackMapFrame {
         }
     }
 
-    fn into_raw(self, cp: &mut ConstantPool) -> Result<Self::Raw, ToWriterError> {
+    fn into_raw(self, cp: &mut ConstantPool) -> Result<Self::Raw, GenerationError> {
         let raw = match self {
             Self::SameFrame { offset_delta } => {
                 if offset_delta < 64 {
@@ -129,7 +129,7 @@ impl ClassElement for StackMapFrame {
 
 impl ClassElement for VerificationType {
     type Raw = raw_attributes::VerificationTypeInfo;
-    fn from_raw(raw: Self::Raw, ctx: &ParsingContext) -> Result<Self, ParsingError> {
+    fn from_raw(raw: Self::Raw, ctx: &ParsingContext) -> Result<Self, ParseError> {
         match raw {
             Self::Raw::Top => Ok(Self::TopVariable),
             Self::Raw::Integer => Ok(Self::IntegerVariable),
@@ -147,7 +147,7 @@ impl ClassElement for VerificationType {
         }
     }
 
-    fn into_raw(self, cp: &mut ConstantPool) -> Result<Self::Raw, ToWriterError> {
+    fn into_raw(self, cp: &mut ConstantPool) -> Result<Self::Raw, GenerationError> {
         match self {
             Self::TopVariable => Ok(Self::Raw::Top),
             Self::IntegerVariable => Ok(Self::Raw::Integer),

--- a/src/jvm/bytecode/code/stack_map.rs
+++ b/src/jvm/bytecode/code/stack_map.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 
 use crate::jvm::{
     bytecode::{
-        ParsingContext, ParseError, errors::GenerationError, jvm_element_parser::ClassElement,
+        ParseError, ParsingContext, errors::GenerationError, jvm_element_parser::ClassElement,
         raw_attributes,
     },
     class::ConstantPool,

--- a/src/jvm/bytecode/constant_pool.rs
+++ b/src/jvm/bytecode/constant_pool.rs
@@ -167,7 +167,7 @@ impl ConstantPool {
             }
             ConstantValue::Null => {
                 return Err(GenerationError::other(
-                    "Null should not be put into constant poll",
+                    "Null should not be put into constant pool",
                 ));
             }
         };

--- a/src/jvm/bytecode/constant_pool.rs
+++ b/src/jvm/bytecode/constant_pool.rs
@@ -358,7 +358,8 @@ impl ConstantPool {
     pub(super) fn get_type_ref(&self, index: u16) -> Result<FieldType, ParsingError> {
         let ClassRef { binary_name: name } = self.get_class_ref(index)?;
         let field_type = if name.starts_with('[') {
-            FieldType::from_str(name.as_str()).context("Invalid descriptor for type reference")?
+            FieldType::from_str(name.as_str())
+                .with_context(|_| format!("Invalid descriptor for type reference: {name}"))?
         } else {
             FieldType::Object(ClassRef::new(name))
         };

--- a/src/jvm/bytecode/constant_pool.rs
+++ b/src/jvm/bytecode/constant_pool.rs
@@ -167,7 +167,7 @@ impl ConstantPool {
             }
             ConstantValue::Null => {
                 return Err(GenerationError::other(
-                    "Null should not be put into constant pull",
+                    "Null should not be put into constant poll",
                 ));
             }
         };

--- a/src/jvm/bytecode/constant_pool.rs
+++ b/src/jvm/bytecode/constant_pool.rs
@@ -87,10 +87,7 @@ impl ConstantPool {
         .map_err(Into::into)
     }
 
-    pub(super) fn get_constant_value(
-        &self,
-        value_index: u16,
-    ) -> Result<ConstantValue, ParseError> {
+    pub(super) fn get_constant_value(&self, value_index: u16) -> Result<ConstantValue, ParseError> {
         let entry = self
             .get_entry(value_index)
             .context("Invalid constant pool index")?;

--- a/src/jvm/bytecode/constant_pool.rs
+++ b/src/jvm/bytecode/constant_pool.rs
@@ -4,6 +4,7 @@ use std::{
     str::FromStr,
 };
 
+use super::errors::ParsingErrorContext;
 use crate::{
     jvm::{
         ConstantValue, JavaString,
@@ -20,8 +21,6 @@ use crate::{
     },
     types::{Descriptor, field_type::FieldType},
 };
-
-use super::errors::ParsingErrorContext;
 
 #[inline]
 fn mismatch<T>(expected: &'static str, entry: &Entry) -> Result<T, ParseError> {

--- a/src/jvm/bytecode/errors.rs
+++ b/src/jvm/bytecode/errors.rs
@@ -41,7 +41,8 @@ impl fmt::Display for ParseError {
             ParseErrorKind::IO => write!(f, "IO Error: {}", self.cause)?,
             ParseErrorKind::Malformed => write!(f, "Malformed class file: {}", self.cause)?,
         }
-        if cfg!(debug_assertions) {
+        #[cfg(debug_assertions)]
+        {
             write!(f, "\nBacktrace: \n{}", self.backtrace)?;
         }
         Ok(())
@@ -210,7 +211,8 @@ impl fmt::Display for GenerationError {
             GenerationErrorKind::ConstantPool => write!(f, "Constant pool error: {}", self.cause)?,
             GenerationErrorKind::Other => write!(f, "Other error: {}", self.cause)?,
         }
-        if cfg!(debug_assertions) {
+        #[cfg(debug_assertions)]
+        {
             write!(f, "\nBacktrace: \n{}", self.backtrace)?;
         }
         Ok(())

--- a/src/jvm/bytecode/errors.rs
+++ b/src/jvm/bytecode/errors.rs
@@ -2,71 +2,134 @@ use std::{io, num::TryFromIntError};
 
 use derive_more::Display;
 
-use crate::{
-    jvm::{class::constant_pool, code::InvalidOffset},
-    types::method_descriptor::InvalidDescriptor,
-};
+use crate::jvm::code::InvalidOffset;
 
-/// An error that occurs when parsing a Java class file.
+/// An error that occurs during parsing of a class file.
 #[derive(Debug, thiserror::Error)]
-pub enum ParsingError {
-    /// An error that occurs when reading from a buffer.
-    #[error("Failed to read from buffer: {0}")]
-    IO(#[from] std::io::Error),
-    /// The format of the class file is invalid.
-    #[error("MalformedClassFile: {0}")]
-    Other(&'static str),
-    /// The constant pool index does not point to a desired entry.
-    #[error("Mismatched constant pool entry, expected {expected}, but found {found}")]
-    MismatchedConstantPoolEntryType {
-        /// The type of the constant pool entry that was expected.
-        expected: &'static str,
-        /// The type of the constant pool entry that was found.
-        found: &'static str,
-    },
-    /// The constant pool index does not point to an entry.
-    #[error("Error when accessing constant pool: {0}")]
-    ConstantPool(#[from] constant_pool::Error),
-    /// An known attribute is found in an unexpected location.
-    #[error("Unexpected attribute {0} in {1}")]
-    UnexpectedAttribute(String, String),
-    /// The value of an element in an annotation is invalid.
-    #[error("Invalid element tag {0}")]
-    InvalidElementValueTag(char),
-    /// The target type of an annotation is invalid.
-    #[error("Invalid target type {0}")]
-    InvalidTargetType(u8),
-    /// The target type of an annotation is invalid.
-    #[error("Invalid type path kind")]
-    InvalidTypePathKind,
-    /// The stack map frame type is invalid.
-    #[error("Unknown stack map frame type {0}")]
-    UnknownStackMapFrameType(u8),
-    /// The verification type info tag is invalid.
-    #[error("Invalid verification type info tag {0}")]
-    InvalidVerificationTypeInfoTag(u8),
-    /// The opcode cannot be recognized when parsing the code attribute.
-    #[error("Unexpected opcode {0:#x}")]
-    UnexpectedOpCode(u8),
-    /// The flags cannot be recognized.
-    #[error("Unknown {0}: {1:#04x}")]
-    UnknownFlags(&'static str, u16),
-    /// The descriptor is invalid.
-    #[error("Fail to parse descriptor: {0}")]
-    InvalidDescriptor(#[from] InvalidDescriptor),
-    /// The constant pool tag is invalid.
-    #[error("Unexpected constant pool tag {0}")]
-    UnexpectedConstantPoolTag(u8),
-    /// The jump target is invalid.
-    #[error("Invalid jump target: {0}")]
-    InvalidJumpTarget(#[from] InvalidOffset),
-    /// Tries to reads a string for constructing JVM components (e.g., class name) but got an invalid UTF-8 string.
-    #[error("Invalid UTF-8 string")]
-    BrokenUTF8,
-    /// The instruction list is too long.
-    #[error("The instruction list is too long, it should be at most 65536 bytes")]
-    TooLongInstructionList,
+pub struct ParsingError {
+    #[source]
+    cause: Box<dyn std::error::Error + Send + Sync>,
+    kind: ParsingErrorKind,
 }
+
+impl std::fmt::Display for ParsingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            ParsingErrorKind::IO => write!(f, "IO Error: {}", self.cause),
+            ParsingErrorKind::Malformed => write!(f, "Malformed class file: {}", self.cause),
+        }
+    }
+}
+
+impl ParsingError {
+    pub(crate) fn malform(message: impl Into<String>) -> Self {
+        Self {
+            cause: message.into().into(),
+            kind: ParsingErrorKind::Malformed,
+        }
+    }
+
+    /// Returns the kind of error.
+    #[must_use]
+    pub const fn kind(&self) -> ParsingErrorKind {
+        self.kind
+    }
+}
+
+impl From<std::io::Error> for ParsingError {
+    fn from(value: std::io::Error) -> Self {
+        Self {
+            cause: value.into(),
+            kind: ParsingErrorKind::IO,
+        }
+    }
+}
+
+/// The Kind of [`ParsingError`].
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ParsingErrorKind {
+    /// Due to an IO error in the underlying reader
+    IO,
+    /// Due to a malformed class file
+    Malformed,
+}
+
+pub(crate) trait ParsingErrorContext {
+    type Output;
+    fn context(self, message: impl Into<String>) -> Result<Self::Output, ParsingError>;
+}
+
+impl<T, E> ParsingErrorContext for Result<T, E>
+where
+    E: std::fmt::Display,
+{
+    type Output = T;
+
+    fn context(self, message: impl Into<String>) -> Result<Self::Output, ParsingError> {
+        self.map_err(|err| ParsingError::malform(format!("{}: {err}", message.into())))
+    }
+}
+
+// /// An error that occurs when parsing a Java class file.
+// #[derive(Debug, thiserror::Error)]
+// pub enum ParsingError {
+//     /// An error that occurs when reading from a buffer.
+//     #[error("Failed to read from buffer: {0}")]
+//     IO(#[from] std::io::Error),
+//     /// The format of the class file is invalid.
+//     #[error("MalformedClassFile: {0}")]
+//     Other(&'static str),
+//     /// The constant pool index does not point to a desired entry.
+//     #[error("Mismatched constant pool entry, expected {expected}, but found {found}")]
+//     MismatchedConstantPoolEntryType {
+//         /// The type of the constant pool entry that was expected.
+//         expected: &'static str,
+//         /// The type of the constant pool entry that was found.
+//         found: &'static str,
+//     },
+//     /// The constant pool index does not point to an entry.
+//     #[error("Error when accessing constant pool: {0}")]
+//     ConstantPool(#[from] constant_pool::Error),
+//     /// An known attribute is found in an unexpected location.
+//     #[error("Unexpected attribute {0} in {1}")]
+//     UnexpectedAttribute(String, String),
+//     /// The value of an element in an annotation is invalid.
+//     #[error("Invalid element tag {0}")]
+//     InvalidElementValueTag(char),
+//     /// The target type of an annotation is invalid.
+//     #[error("Invalid target type {0}")]
+//     InvalidTargetType(u8),
+//     /// The target type of an annotation is invalid.
+//     #[error("Invalid type path kind")]
+//     InvalidTypePathKind,
+//     /// The stack map frame type is invalid.
+//     #[error("Unknown stack map frame type {0}")]
+//     UnknownStackMapFrameType(u8),
+//     /// The verification type info tag is invalid.
+//     #[error("Invalid verification type info tag {0}")]
+//     InvalidVerificationTypeInfoTag(u8),
+//     /// The opcode cannot be recognized when parsing the code attribute.
+//     #[error("Unexpected opcode {0:#x}")]
+//     UnexpectedOpCode(u8),
+//     /// The flags cannot be recognized.
+//     #[error("Unknown {0}: {1:#04x}")]
+//     UnknownFlags(&'static str, u16),
+//     /// The descriptor is invalid.
+//     #[error("Fail to parse descriptor: {0}")]
+//     InvalidDescriptor(#[from] InvalidDescriptor),
+//     /// The constant pool tag is invalid.
+//     #[error("Unexpected constant pool tag {0}")]
+//     UnexpectedConstantPoolTag(u8),
+//     /// The jump target is invalid.
+//     #[error("Invalid jump target: {0}")]
+//     InvalidJumpTarget(#[from] InvalidOffset),
+//     /// Tries to reads a string for constructing JVM components (e.g., class name) but got an invalid UTF-8 string.
+//     #[error("Invalid UTF-8 string")]
+//     BrokenUTF8,
+//     /// The instruction list is too long.
+//     #[error("The instruction list is too long, it should be at most 65536 bytes")]
+//     TooLongInstructionList,
+// }
 
 /// Error that can occur when writing a Raw JVM element to a writer.
 #[derive(Debug, Display, thiserror::Error)]

--- a/src/jvm/bytecode/errors.rs
+++ b/src/jvm/bytecode/errors.rs
@@ -95,6 +95,7 @@ impl From<std::io::Error> for ParseError {
 /// This enum represents the different categories of errors that can occur
 /// during parsing of a class file.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[non_exhaustive]
 pub enum ParseErrorKind {
     /// An error occurred while reading from the underlying input source.
     IO,
@@ -221,6 +222,7 @@ impl fmt::Display for GenerationError {
 /// This enum represents the different categories of errors that can occur
 /// during bytecode generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum GenerationErrorKind {
     /// An error occurred while writing to the underlying output destination.
     IO,

--- a/src/jvm/bytecode/errors.rs
+++ b/src/jvm/bytecode/errors.rs
@@ -30,7 +30,7 @@ impl fmt::Display for ParseError {
             ParsingErrorKind::Malformed => write!(f, "Malformed class file: {}", self.cause)?,
         }
         if cfg!(debug_assertions) {
-            write!(f, "Backtrace: \n{}", self.backtrace)?;
+            write!(f, "\nBacktrace: \n{}", self.backtrace)?;
         }
         Ok(())
     }
@@ -157,7 +157,7 @@ impl fmt::Display for GenerationError {
             GenerationErrorKind::Other => write!(f, "Other error: {}", self.cause)?,
         }
         if cfg!(debug_assertions) {
-            write!(f, "Backtrace: \n{}", self.backtrace)?;
+            write!(f, "\nBacktrace: \n{}", self.backtrace)?;
         }
         Ok(())
     }

--- a/src/jvm/bytecode/errors.rs
+++ b/src/jvm/bytecode/errors.rs
@@ -163,11 +163,16 @@ impl fmt::Display for GenerationError {
     }
 }
 
+/// The kind of [`GenerationError`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GenerationErrorKind {
+    /// Due to an IO error in the underlying writer
     IO,
+    /// The length of a list if beyond the max value of the data type to store the range. For instance an instruction list containing more than 65535 instructions.
     OutOfRange,
+    /// An error when operating the constant pool
     ConstantPool,
+    /// Other errors
     Other,
 }
 

--- a/src/jvm/bytecode/errors.rs
+++ b/src/jvm/bytecode/errors.rs
@@ -24,7 +24,7 @@ use crate::jvm::{class::constant_pool, code::InvalidOffset};
 #[derive(Debug)]
 pub struct ParseError {
     cause: Box<dyn Error + Send + Sync>,
-    kind: ParsingErrorKind,
+    kind: ParseErrorKind,
     #[cfg(debug_assertions)]
     backtrace: Backtrace,
 }
@@ -38,8 +38,8 @@ impl Error for ParseError {
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
-            ParsingErrorKind::IO => write!(f, "IO Error: {}", self.cause)?,
-            ParsingErrorKind::Malformed => write!(f, "Malformed class file: {}", self.cause)?,
+            ParseErrorKind::IO => write!(f, "IO Error: {}", self.cause)?,
+            ParseErrorKind::Malformed => write!(f, "Malformed class file: {}", self.cause)?,
         }
         if cfg!(debug_assertions) {
             write!(f, "\nBacktrace: \n{}", self.backtrace)?;
@@ -57,7 +57,7 @@ impl ParseError {
     pub(crate) fn malform(message: impl fmt::Display) -> Self {
         Self {
             cause: format!("{message}").into(),
-            kind: ParsingErrorKind::Malformed,
+            kind: ParseErrorKind::Malformed,
             #[cfg(debug_assertions)]
             backtrace: Backtrace::capture(),
         }
@@ -71,7 +71,7 @@ impl ParseError {
     pub(crate) fn io(error: io::Error) -> Self {
         Self {
             cause: error.into(),
-            kind: ParsingErrorKind::IO,
+            kind: ParseErrorKind::IO,
             #[cfg(debug_assertions)]
             backtrace: Backtrace::capture(),
         }
@@ -79,7 +79,7 @@ impl ParseError {
 
     /// Returns the kind of error.
     #[must_use]
-    pub const fn kind(&self) -> ParsingErrorKind {
+    pub const fn kind(&self) -> ParseErrorKind {
         self.kind
     }
 }
@@ -95,7 +95,7 @@ impl From<std::io::Error> for ParseError {
 /// This enum represents the different categories of errors that can occur
 /// during parsing of a class file.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum ParsingErrorKind {
+pub enum ParseErrorKind {
     /// An error occurred while reading from the underlying input source.
     IO,
     /// The class file is malformed and does not conform to the JVM specification.

--- a/src/jvm/bytecode/field_info.rs
+++ b/src/jvm/bytecode/field_info.rs
@@ -3,7 +3,7 @@ use std::io::{self, Read};
 use itertools::Itertools;
 
 use super::{
-    FromReader, ParsingContext, ParseError, ToWriter,
+    FromReader, ParseError, ParsingContext, ToWriter,
     attribute::{Attribute, AttributeInfo},
     errors::GenerationError,
     jvm_element_parser::ClassElement,

--- a/src/jvm/bytecode/field_info.rs
+++ b/src/jvm/bytecode/field_info.rs
@@ -3,11 +3,11 @@ use std::io::{self, Read};
 use itertools::Itertools;
 
 use super::{
-    FromReader, ParseError, ParsingContext, ToWriter,
+    FromBytecode, ParseError, ParsingContext, ToBytecode,
     attribute::{Attribute, AttributeInfo},
     errors::GenerationError,
     jvm_element_parser::ClassElement,
-    reader_utils::ValueReaderExt,
+    reader_utils::BytecodeReader,
 };
 use crate::{
     jvm::{
@@ -30,12 +30,12 @@ pub(crate) struct FieldInfo {
     attributes: Vec<AttributeInfo>,
 }
 
-impl FromReader for FieldInfo {
+impl FromBytecode for FieldInfo {
     fn from_reader<R: Read + ?Sized>(reader: &mut R) -> io::Result<Self> {
-        let access_flags = reader.read_value()?;
-        let name_index = reader.read_value()?;
-        let descriptor_index = reader.read_value()?;
-        let attributes_count: u16 = reader.read_value()?;
+        let access_flags = reader.decode_value()?;
+        let name_index = reader.decode_value()?;
+        let descriptor_index = reader.decode_value()?;
+        let attributes_count: u16 = reader.decode_value()?;
         let attributes = (0..attributes_count)
             .map(|_| AttributeInfo::from_reader(reader))
             .collect::<io::Result<_>>()?;
@@ -48,7 +48,7 @@ impl FromReader for FieldInfo {
     }
 }
 
-impl ToWriter for FieldInfo {
+impl ToBytecode for FieldInfo {
     fn to_writer<W: io::Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.access_flags.to_be_bytes())?;
         writer.write_all(&self.name_index.to_be_bytes())?;

--- a/src/jvm/bytecode/field_info.rs
+++ b/src/jvm/bytecode/field_info.rs
@@ -12,6 +12,7 @@ use super::{
 use crate::{
     jvm::{
         Field,
+        bytecode::errors::ParsingErrorContext,
         field::{self},
         references::ClassRef,
     },
@@ -68,9 +69,13 @@ impl ClassElement for Field {
             attributes,
         } = raw;
         let access_flags = field::AccessFlags::from_bits(access_flags)
-            .ok_or(ParsingError::UnknownFlags("FieldAccessFlag", access_flags))?;
+            .ok_or(ParsingError::malform("Invalid field access flags"))?;
         let name = ctx.constant_pool.get_str(name_index)?.to_owned();
-        let field_type = ctx.constant_pool.get_str(descriptor_index)?.parse()?;
+        let field_type = ctx
+            .constant_pool
+            .get_str(descriptor_index)?
+            .parse()
+            .context("Invalid field descriptor")?;
         let owner = ClassRef {
             binary_name: ctx.current_class_binary_name.clone(),
         };

--- a/src/jvm/bytecode/jvm_element_parser.rs
+++ b/src/jvm/bytecode/jvm_element_parser.rs
@@ -27,10 +27,7 @@ where
     type Raw = u16;
 
     fn from_raw(raw: Self::Raw, _ctx: &ParsingContext) -> Result<Self, ParsingError> {
-        T::from_bits(raw).ok_or(ParsingError::UnknownFlags(
-            std::any::type_name::<Self>(),
-            raw,
-        ))
+        T::from_bits(raw).ok_or(ParsingError::malform("Invalid access flag"))
     }
 
     fn into_raw(self, _cp: &mut ConstantPool) -> Result<Self::Raw, ToWriterError> {

--- a/src/jvm/bytecode/jvm_element_parser.rs
+++ b/src/jvm/bytecode/jvm_element_parser.rs
@@ -1,6 +1,6 @@
 use bitflags::Flags;
 
-use super::{ParseError, ParsingContext, ToWriter, errors::GenerationError};
+use super::{ParseError, ParsingContext, ToBytecode, errors::GenerationError};
 use crate::jvm::class::ConstantPool;
 
 pub(super) trait ClassElement: Sized {
@@ -12,7 +12,7 @@ pub(super) trait ClassElement: Sized {
 
     fn into_bytes(self, cp: &mut ConstantPool) -> Result<Vec<u8>, GenerationError>
     where
-        Self::Raw: ToWriter,
+        Self::Raw: ToBytecode,
     {
         let mut bytes = Vec::new();
         self.into_raw(cp)?.to_writer(&mut bytes)?;

--- a/src/jvm/bytecode/jvm_element_parser.rs
+++ b/src/jvm/bytecode/jvm_element_parser.rs
@@ -1,6 +1,6 @@
 use bitflags::Flags;
 
-use super::{ParsingContext, ParseError, ToWriter, errors::GenerationError};
+use super::{ParseError, ParsingContext, ToWriter, errors::GenerationError};
 use crate::jvm::class::ConstantPool;
 
 pub(super) trait ClassElement: Sized {

--- a/src/jvm/bytecode/jvm_element_parser.rs
+++ b/src/jvm/bytecode/jvm_element_parser.rs
@@ -1,16 +1,16 @@
 use bitflags::Flags;
 
-use super::{ParsingContext, ParsingError, ToWriter, errors::ToWriterError};
+use super::{ParsingContext, ParseError, ToWriter, errors::GenerationError};
 use crate::jvm::class::ConstantPool;
 
 pub(super) trait ClassElement: Sized {
     type Raw: Sized;
 
-    fn from_raw(raw: Self::Raw, ctx: &ParsingContext) -> Result<Self, ParsingError>;
+    fn from_raw(raw: Self::Raw, ctx: &ParsingContext) -> Result<Self, ParseError>;
 
-    fn into_raw(self, cp: &mut ConstantPool) -> Result<Self::Raw, ToWriterError>;
+    fn into_raw(self, cp: &mut ConstantPool) -> Result<Self::Raw, GenerationError>;
 
-    fn into_bytes(self, cp: &mut ConstantPool) -> Result<Vec<u8>, ToWriterError>
+    fn into_bytes(self, cp: &mut ConstantPool) -> Result<Vec<u8>, GenerationError>
     where
         Self::Raw: ToWriter,
     {
@@ -26,11 +26,11 @@ where
 {
     type Raw = u16;
 
-    fn from_raw(raw: Self::Raw, _ctx: &ParsingContext) -> Result<Self, ParsingError> {
-        T::from_bits(raw).ok_or(ParsingError::malform("Invalid access flag"))
+    fn from_raw(raw: Self::Raw, _ctx: &ParsingContext) -> Result<Self, ParseError> {
+        T::from_bits(raw).ok_or(ParseError::malform("Invalid access flag"))
     }
 
-    fn into_raw(self, _cp: &mut ConstantPool) -> Result<Self::Raw, ToWriterError> {
+    fn into_raw(self, _cp: &mut ConstantPool) -> Result<Self::Raw, GenerationError> {
         Ok(self.bits())
     }
 }

--- a/src/jvm/bytecode/method_info.rs
+++ b/src/jvm/bytecode/method_info.rs
@@ -3,11 +3,11 @@ use std::io::{self, Read};
 use itertools::Itertools;
 
 use super::{
-    FromReader, ParseError, ToWriter,
+    FromBytecode, ParseError, ToBytecode,
     attribute::{Attribute, AttributeInfo},
     errors::GenerationError,
     jvm_element_parser::ClassElement,
-    reader_utils::ValueReaderExt,
+    reader_utils::BytecodeReader,
 };
 use crate::{
     jvm::{
@@ -30,12 +30,12 @@ pub(super) struct MethodInfo {
     attributes: Vec<AttributeInfo>,
 }
 
-impl FromReader for MethodInfo {
+impl FromBytecode for MethodInfo {
     fn from_reader<R: Read + ?Sized>(reader: &mut R) -> io::Result<Self> {
-        let access_flags = reader.read_value()?;
-        let name_index = reader.read_value()?;
-        let descriptor_index = reader.read_value()?;
-        let attributes_count: u16 = reader.read_value()?;
+        let access_flags = reader.decode_value()?;
+        let name_index = reader.decode_value()?;
+        let descriptor_index = reader.decode_value()?;
+        let attributes_count: u16 = reader.decode_value()?;
         let attributes = (0..attributes_count)
             .map(|_| AttributeInfo::from_reader(reader))
             .collect::<io::Result<_>>()?;
@@ -48,7 +48,7 @@ impl FromReader for MethodInfo {
     }
 }
 
-impl ToWriter for MethodInfo {
+impl ToBytecode for MethodInfo {
     fn to_writer<W: io::Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.access_flags.to_be_bytes())?;
         writer.write_all(&self.name_index.to_be_bytes())?;

--- a/src/jvm/bytecode/mod.rs
+++ b/src/jvm/bytecode/mod.rs
@@ -41,7 +41,7 @@ pub struct ParsingContext {
 /// Enables parsing a raw JVM element from a binary stream.
 ///
 /// This trait is implemented by raw JVM elements (without resolving constant pool references) that can be parsed from a binary input stream.
-trait FromReader {
+trait FromBytecode {
     /// Parses an instance of this type from the given reader.
     ///
     /// # Errors
@@ -56,7 +56,7 @@ trait FromReader {
 ///
 /// This trait is implemented by raw JVM elements (after putting all the constants in the constant pool) that can be serialized to a class file format.
 /// It provides a standardized way to write JVM elements back to binary form.
-trait ToWriter {
+trait ToBytecode {
     /// Writes this element to the given writer in JVM class file format.
     ///
     /// # Errors

--- a/src/jvm/bytecode/mod.rs
+++ b/src/jvm/bytecode/mod.rs
@@ -17,7 +17,7 @@ use std::{
     num::TryFromIntError,
 };
 
-pub use errors::{GenerationError, GenerationErrorKind, ParseError, ParsingErrorKind};
+pub use errors::{GenerationError, GenerationErrorKind, ParseError, ParseErrorKind};
 use num_traits::ToBytes;
 
 use crate::jvm::class::{ConstantPool, Version};

--- a/src/jvm/bytecode/mod.rs
+++ b/src/jvm/bytecode/mod.rs
@@ -17,7 +17,7 @@ use std::{
     num::TryFromIntError,
 };
 
-pub use errors::{GenerationError, ParseError, ParsingErrorKind};
+pub use errors::{GenerationError, GenerationErrorKind, ParseError, ParsingErrorKind};
 use num_traits::ToBytes;
 
 use crate::jvm::class::{ConstantPool, Version};

--- a/src/jvm/bytecode/mod.rs
+++ b/src/jvm/bytecode/mod.rs
@@ -17,7 +17,7 @@ use std::{
     num::TryFromIntError,
 };
 
-pub use errors::{ParsingError, ToWriterError};
+pub use errors::{ParsingError, ParsingErrorKind, ToWriterError};
 use num_traits::ToBytes;
 
 use crate::jvm::class::{ConstantPool, Version};

--- a/src/jvm/bytecode/mod.rs
+++ b/src/jvm/bytecode/mod.rs
@@ -17,7 +17,7 @@ use std::{
     num::TryFromIntError,
 };
 
-pub use errors::{ParsingError, ParsingErrorKind, ToWriterError};
+pub use errors::{GenerationError, ParseError, ParsingErrorKind};
 use num_traits::ToBytes;
 
 use crate::jvm::class::{ConstantPool, Version};
@@ -62,7 +62,7 @@ trait ToWriter {
     /// # Errors
     /// Returns a `ToWriterError` if writing to the stream fails or if the data
     /// cannot be properly serialized (e.g., if a numeric value is out of range).
-    fn to_writer<W>(&self, writer: &mut W) -> Result<(), ToWriterError>
+    fn to_writer<W>(&self, writer: &mut W) -> Result<(), GenerationError>
     where
         W: Write + ?Sized;
 }
@@ -79,7 +79,10 @@ trait ToWriter {
 /// Returns a `ToWriterError` if:
 /// - The length value cannot fit in the target type
 /// - Writing to the output stream fails
-fn write_length<Len>(writer: &mut (impl Write + ?Sized), length: usize) -> Result<(), ToWriterError>
+fn write_length<Len>(
+    writer: &mut (impl Write + ?Sized),
+    length: usize,
+) -> Result<(), GenerationError>
 where
     usize: TryInto<Len, Error = TryFromIntError>,
     Len: ToBytes,

--- a/src/jvm/bytecode/module.rs
+++ b/src/jvm/bytecode/module.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 
 use super::{
-    GenerationError, ParsingContext, ParseError, errors::ParsingErrorContext,
+    GenerationError, ParseError, ParsingContext, errors::ParsingErrorContext,
     jvm_element_parser::ClassElement, raw_attributes,
 };
 use crate::jvm::{

--- a/src/jvm/bytecode/raw_attributes/mod.rs
+++ b/src/jvm/bytecode/raw_attributes/mod.rs
@@ -7,7 +7,7 @@ use std::{
 use super::{
     FromReader, ToWriter,
     attribute::AttributeInfo,
-    errors::ToWriterError,
+    errors::GenerationError,
     reader_utils::{ValueReaderExt, read_byte_chunk},
     write_length,
 };
@@ -49,7 +49,7 @@ impl FromReader for Code {
 }
 
 impl ToWriter for Code {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.max_stack.to_be_bytes())?;
         writer.write_all(&self.max_locals.to_be_bytes())?;
         write_length::<u32>(writer, self.instruction_bytes.len())?;
@@ -84,7 +84,7 @@ impl FromReader for ExceptionTableEntry {
 }
 
 impl ToWriter for ExceptionTableEntry {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.start_pc.to_be_bytes())?;
         writer.write_all(&self.end_pc.to_be_bytes())?;
         writer.write_all(&self.handler_pc.to_be_bytes())?;
@@ -182,7 +182,7 @@ impl FromReader for StackMapFrameInfo {
 }
 
 impl ToWriter for StackMapFrameInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         match self {
             Self::SameFrame { frame_type } => {
                 debug_assert!(
@@ -304,7 +304,7 @@ impl FromReader for VerificationTypeInfo {
 }
 
 impl ToWriter for VerificationTypeInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         let tag = self.tag();
         writer.write_all(&tag.to_be_bytes())?;
         match self {
@@ -337,7 +337,7 @@ impl FromReader for InnerClass {
 }
 
 impl ToWriter for InnerClass {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.info_index.to_be_bytes())?;
         writer.write_all(&self.outer_class_info_index.to_be_bytes())?;
         writer.write_all(&self.inner_name_index.to_be_bytes())?;
@@ -361,7 +361,7 @@ impl FromReader for EnclosingMethod {
 }
 
 impl ToWriter for EnclosingMethod {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.class_index.to_be_bytes())?;
         writer.write_all(&self.method_index.to_be_bytes())?;
         Ok(())
@@ -389,7 +389,7 @@ impl FromReader for LocalVariableInfo {
 }
 
 impl ToWriter for LocalVariableInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&u16::from(self.start_pc).to_be_bytes())?;
         writer.write_all(&self.length.to_be_bytes())?;
         writer.write_all(&self.name_index.to_be_bytes())?;
@@ -423,7 +423,7 @@ impl FromReader for Annotation {
 }
 
 impl ToWriter for Annotation {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.type_index.to_be_bytes())?;
         write_length::<u16>(writer, self.element_value_pairs.len())?;
         for (element_name_index, element_value) in &self.element_value_pairs {
@@ -474,7 +474,7 @@ impl FromReader for ElementValueInfo {
 }
 
 impl ToWriter for ElementValueInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         let tag = self.tag();
         writer.write_all(&tag.to_be_bytes())?;
         match self {
@@ -549,7 +549,7 @@ impl FromReader for TypeAnnotation {
 }
 
 impl ToWriter for TypeAnnotation {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         self.target_info.to_writer(writer)?;
         write_length::<u8>(writer, self.target_path.len())?;
         for (type_path_kind, type_argument_index) in &self.target_path {
@@ -732,7 +732,7 @@ impl FromReader for TargetInfo {
 }
 
 impl ToWriter for TargetInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         // Safety: Self is marked as repr(u8) so it is fine to use enum_discriminant
         let target_type: u8 = unsafe { enum_discriminant(self) };
         writer.write_all(&target_type.to_be_bytes())?;
@@ -804,7 +804,7 @@ impl FromReader for BootstrapMethod {
 }
 
 impl ToWriter for BootstrapMethod {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.method_ref_idx.to_be_bytes())?;
         write_length::<u16>(writer, self.arguments.len())?;
         for argument in &self.arguments {
@@ -829,7 +829,7 @@ impl FromReader for ParameterInfo {
 }
 
 impl ToWriter for ParameterInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.name_index.to_be_bytes())?;
         writer.write_all(&self.access_flags.to_be_bytes())?;
         Ok(())
@@ -886,7 +886,7 @@ impl FromReader for ModuleInfo {
 }
 
 impl ToWriter for ModuleInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.info_index.to_be_bytes())?;
         writer.write_all(&self.flags.to_be_bytes())?;
         writer.write_all(&self.version_index.to_be_bytes())?;
@@ -931,7 +931,7 @@ impl FromReader for RequiresInfo {
 }
 
 impl ToWriter for RequiresInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.requires_index.to_be_bytes())?;
         writer.write_all(&self.flags.to_be_bytes())?;
         writer.write_all(&self.version_index.to_be_bytes())?;
@@ -962,7 +962,7 @@ impl FromReader for ExportsInfo {
 }
 
 impl ToWriter for ExportsInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.exports_index.to_be_bytes())?;
         writer.write_all(&self.flags.to_be_bytes())?;
         write_length::<u16>(writer, self.to.len())?;
@@ -996,7 +996,7 @@ impl FromReader for OpensInfo {
 }
 
 impl ToWriter for OpensInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.opens_index.to_be_bytes())?;
         writer.write_all(&self.flags.to_be_bytes())?;
         write_length::<u16>(writer, self.to.len())?;
@@ -1027,7 +1027,7 @@ impl FromReader for ProvidesInfo {
 }
 
 impl ToWriter for ProvidesInfo {
-    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), ToWriterError> {
+    fn to_writer<W: Write + ?Sized>(&self, writer: &mut W) -> Result<(), GenerationError> {
         writer.write_all(&self.provides_index.to_be_bytes())?;
         write_length::<u16>(writer, self.with.len())?;
         for with in &self.with {
@@ -1060,7 +1060,7 @@ impl FromReader for RecordComponentInfo {
 }
 
 impl ToWriter for RecordComponentInfo {
-    fn to_writer<W>(&self, writer: &mut W) -> Result<(), ToWriterError>
+    fn to_writer<W>(&self, writer: &mut W) -> Result<(), GenerationError>
     where
         W: Write + ?Sized,
     {

--- a/src/jvm/bytecode/reader_utils.rs
+++ b/src/jvm/bytecode/reader_utils.rs
@@ -81,9 +81,8 @@ where
     R: Read,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let n = self.inner.read(buf)?;
-        self.position += n;
-        Ok(n)
+        let Self { inner, position } = self;
+        inner.read(buf).inspect(|n| position.add_assign(n))
     }
 }
 
@@ -92,9 +91,8 @@ where
     W: Write,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        let n = self.inner.write(buf)?;
-        self.position += n;
-        Ok(n)
+        let Self { inner, position } = self;
+        inner.write(buf).inspect(|n| position.add_assign(n))
     }
 
     fn flush(&mut self) -> Result<()> {

--- a/src/jvm/class/mod.rs
+++ b/src/jvm/class/mod.rs
@@ -190,7 +190,7 @@ impl Version {
             (68, 0x0000) => Ok(Self::Jdk24(false)),
             (68, 0xFFFF) => Ok(Self::Jdk24(true)),
             (major, _) if major > MAX_MAJOR_VERSION => {
-                Err(ParseError::malform("Unsupportted class version"))
+                Err(ParseError::malform("Unsupported class version"))
             }
             _ => Err(ParseError::malform("Invalid class version")),
         }

--- a/src/jvm/class/mod.rs
+++ b/src/jvm/class/mod.rs
@@ -150,7 +150,7 @@ pub enum Version {
     Jdk24(bool),
 }
 impl Version {
-    pub(crate) const fn from_versions(major: u16, minor: u16) -> Result<Self, ParsingError> {
+    pub(crate) fn from_versions(major: u16, minor: u16) -> Result<Self, ParsingError> {
         match (major, minor) {
             (45, minor) => Ok(Self::Jdk1_1(minor)),
             (46, 0x0000) => Ok(Self::Jdk1_2),
@@ -190,9 +190,9 @@ impl Version {
             (68, 0x0000) => Ok(Self::Jdk24(false)),
             (68, 0xFFFF) => Ok(Self::Jdk24(true)),
             (major, _) if major > MAX_MAJOR_VERSION => {
-                Err(ParsingError::Other("Unsupportted class version"))
+                Err(ParsingError::malform("Unsupportted class version"))
             }
-            _ => Err(ParsingError::Other("Invalid class version")),
+            _ => Err(ParsingError::malform("Invalid class version")),
         }
     }
 

--- a/src/jvm/class/mod.rs
+++ b/src/jvm/class/mod.rs
@@ -9,7 +9,7 @@ use bitflags::bitflags;
 use super::{
     Annotation, Class, ConstantValue, Field, Method,
     annotation::ElementValue,
-    bytecode::ParsingError,
+    bytecode::ParseError,
     field,
     references::{ClassRef, FieldRef, MethodRef},
 };
@@ -150,7 +150,7 @@ pub enum Version {
     Jdk24(bool),
 }
 impl Version {
-    pub(crate) fn from_versions(major: u16, minor: u16) -> Result<Self, ParsingError> {
+    pub(crate) fn from_versions(major: u16, minor: u16) -> Result<Self, ParseError> {
         match (major, minor) {
             (45, minor) => Ok(Self::Jdk1_1(minor)),
             (46, 0x0000) => Ok(Self::Jdk1_2),
@@ -190,9 +190,9 @@ impl Version {
             (68, 0x0000) => Ok(Self::Jdk24(false)),
             (68, 0xFFFF) => Ok(Self::Jdk24(true)),
             (major, _) if major > MAX_MAJOR_VERSION => {
-                Err(ParsingError::malform("Unsupportted class version"))
+                Err(ParseError::malform("Unsupportted class version"))
             }
-            _ => Err(ParsingError::malform("Invalid class version")),
+            _ => Err(ParseError::malform("Invalid class version")),
         }
     }
 

--- a/src/jvm/class_loader/mod.rs
+++ b/src/jvm/class_loader/mod.rs
@@ -13,7 +13,7 @@ pub enum Error {
     NotFound,
     /// Error occurred while parsing the class bytes.
     #[error("Error parsing class bytes: {0}")]
-    Malformed(#[from] super::bytecode::errors::ParsingError),
+    Malformed(#[from] super::bytecode::errors::ParseError),
     /// Error occurred while reading the class bytes or locating the class file.
     #[error("IO error: {0}")]
     IO(#[from] std::io::Error),

--- a/src/jvm/code/method_body.rs
+++ b/src/jvm/code/method_body.rs
@@ -295,9 +295,7 @@ impl LocalVariableTable {
         let entry = self.entries.entry(key).or_default();
         if let Some(existing_name) = entry.name.as_ref() {
             if existing_name != &name {
-                Err(ParseError::malform(
-                    "Name of local variable does not match",
-                ))?;
+                Err(ParseError::malform("Name of local variable does not match"))?;
             }
         }
         entry.name = Some(name);
@@ -314,9 +312,7 @@ impl LocalVariableTable {
         let entry = self.entries.entry(key).or_default();
         if let Some(existing_name) = entry.name.as_ref() {
             if existing_name != &name {
-                Err(ParseError::malform(
-                    "Name of local variable does not match",
-                ))?;
+                Err(ParseError::malform("Name of local variable does not match"))?;
             }
         }
         entry.name = Some(name);

--- a/src/jvm/code/method_body.rs
+++ b/src/jvm/code/method_body.rs
@@ -168,7 +168,7 @@ impl<I> InstructionList<I> {
 impl InstructionList<RawInstruction> {
     /// Lifts an [`InstructionList<RawInstruction>`] to an [`InstructionList<Instruction>`] given the constant pool.
     /// # Errors
-    /// See [`ParsingError`] for possible errors.
+    /// See [`ParseError`] for possible errors.
     pub fn lift(
         self,
         constant_pool: &ConstantPool,

--- a/src/jvm/code/method_body.rs
+++ b/src/jvm/code/method_body.rs
@@ -7,7 +7,7 @@ use std::{
 use super::{Instruction, ProgramCounter, RawInstruction};
 use crate::{
     jvm::{TypeAnnotation, bytecode::ParsingError, class::ConstantPool, references::ClassRef},
-    macros::{malform, see_jvm_spec},
+    macros::see_jvm_spec,
     types::field_type::FieldType,
 };
 
@@ -295,7 +295,9 @@ impl LocalVariableTable {
         let entry = self.entries.entry(key).or_default();
         if let Some(existing_name) = entry.name.as_ref() {
             if existing_name != &name {
-                malform!("Name of local variable does not match");
+                Err(ParsingError::malform(
+                    "Name of local variable does not match",
+                ))?;
             }
         }
         entry.name = Some(name);
@@ -312,7 +314,9 @@ impl LocalVariableTable {
         let entry = self.entries.entry(key).or_default();
         if let Some(existing_name) = entry.name.as_ref() {
             if existing_name != &name {
-                malform!("Name of local variable does not match");
+                Err(ParsingError::malform(
+                    "Name of local variable does not match",
+                ))?;
             }
         }
         entry.name = Some(name);

--- a/src/jvm/code/method_body.rs
+++ b/src/jvm/code/method_body.rs
@@ -6,7 +6,7 @@ use std::{
 
 use super::{Instruction, ProgramCounter, RawInstruction};
 use crate::{
-    jvm::{TypeAnnotation, bytecode::ParsingError, class::ConstantPool, references::ClassRef},
+    jvm::{TypeAnnotation, bytecode::ParseError, class::ConstantPool, references::ClassRef},
     macros::see_jvm_spec,
     types::field_type::FieldType,
 };
@@ -172,7 +172,7 @@ impl InstructionList<RawInstruction> {
     pub fn lift(
         self,
         constant_pool: &ConstantPool,
-    ) -> Result<InstructionList<Instruction>, ParsingError> {
+    ) -> Result<InstructionList<Instruction>, ParseError> {
         let mut instructions = BTreeMap::new();
         for (pc, raw_instruction) in self {
             let instruction =
@@ -291,11 +291,11 @@ impl LocalVariableTable {
         key: LocalVariableId,
         name: String,
         field_type: FieldType,
-    ) -> Result<(), ParsingError> {
+    ) -> Result<(), ParseError> {
         let entry = self.entries.entry(key).or_default();
         if let Some(existing_name) = entry.name.as_ref() {
             if existing_name != &name {
-                Err(ParsingError::malform(
+                Err(ParseError::malform(
                     "Name of local variable does not match",
                 ))?;
             }
@@ -310,11 +310,11 @@ impl LocalVariableTable {
         key: LocalVariableId,
         name: String,
         signature: String,
-    ) -> Result<(), ParsingError> {
+    ) -> Result<(), ParseError> {
         let entry = self.entries.entry(key).or_default();
         if let Some(existing_name) = entry.name.as_ref() {
             if existing_name != &name {
-                Err(ParsingError::malform(
+                Err(ParseError::malform(
                     "Name of local variable does not match",
                 ))?;
             }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,7 +22,7 @@ macro_rules! extract_attributes {
                             " in a ",
                             $env
                         );
-                        Err(ParsingError::malform(message))?;
+                        Err(ParseError::malform(message))?;
                     },
                 )*
                 $(
@@ -35,7 +35,7 @@ macro_rules! extract_attributes {
                         $unrecognized.push((name, bytes));
                     }
                     unexpected => {
-                        Err(ParsingError::malform(format!("Unexpected attribute. Expected: {}, but got: {}",
+                        Err(ParseError::malform(format!("Unexpected attribute. Expected: {}, but got: {}",
                             unexpected.name(),
                             $env
                         )))?;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,7 +22,7 @@ macro_rules! extract_attributes {
                             " in a ",
                             $env
                         );
-                        Err(ParsingError::Other(message))?;
+                        Err(ParsingError::malform(message))?;
                     },
                 )*
                 $(
@@ -35,21 +35,15 @@ macro_rules! extract_attributes {
                         $unrecognized.push((name, bytes));
                     }
                     unexpected => {
-                        Err(ParsingError::UnexpectedAttribute(
-                            unexpected.name().to_owned(),
-                            $env.to_owned()
-                        ))?;
+                        Err(ParsingError::malform(format!("Unexpected attribute. Expected: {}, but got: {}",
+                            unexpected.name(),
+                            $env
+                        )))?;
                     }
                 }
             }
         }
         $( $(let $var = $var.$uw();)? )*
-    };
-}
-
-macro_rules! malform {
-    ($msg:expr_2021) => {
-        Err(ParsingError::Other($msg))?
     };
 }
 
@@ -92,5 +86,4 @@ macro_rules! attributes_into_iter {
 
 pub(crate) use attributes_into_iter;
 pub(crate) use extract_attributes;
-pub(crate) use malform;
 pub(crate) use see_jvm_spec;

--- a/tests/class_parsing.rs
+++ b/tests/class_parsing.rs
@@ -1,9 +1,7 @@
-use std::io::{self};
-
 use mokapot::{
     jvm::{
         Class,
-        bytecode::ParsingError,
+        bytecode::ParsingErrorKind,
         class::{self, AccessFlags, RecordComponent},
         references::ClassRef,
     },
@@ -168,8 +166,6 @@ fn parse_record() {
 #[cfg_attr(not(integration_test), ignore)]
 fn not_a_class_file() {
     let mut bytes = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml")).as_slice();
-    assert!(matches!(
-        Class::from_reader(&mut bytes),
-        Err(ParsingError::IO(e)) if e.kind() == io::ErrorKind::InvalidData
-    ));
+    let result = Class::from_reader(&mut bytes);
+    assert!(result.is_err_and(|err| err.kind() == ParsingErrorKind::IO));
 }

--- a/tests/class_parsing.rs
+++ b/tests/class_parsing.rs
@@ -1,7 +1,7 @@
 use mokapot::{
     jvm::{
         Class,
-        bytecode::ParsingErrorKind,
+        bytecode::ParseErrorKind,
         class::{self, AccessFlags, RecordComponent},
         references::ClassRef,
     },
@@ -167,5 +167,5 @@ fn parse_record() {
 fn not_a_class_file() {
     let mut bytes = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml")).as_slice();
     let result = Class::from_reader(&mut bytes);
-    assert!(result.is_err_and(|err| err.kind() == ParsingErrorKind::IO));
+    assert!(result.is_err_and(|err| err.kind() == ParseErrorKind::IO));
 }


### PR DESCRIPTION
Basically we hide the unnecessary details of the underlying error from the library user. For example, we do not tell where the byte code goes wrong as the library user cannot do anything about it.