### PR TITLE
fix(ir): Caught exception should have a location

### DIFF
--- a/src/ir/generator/mod.rs
+++ b/src/ir/generator/mod.rs
@@ -156,7 +156,7 @@ impl<'m> MokaIRGenerator<'m> {
             .into_group_map_by(|&it| it.handler_pc)
             .into_iter()
             .map(|(handler_pc, entries)| {
-                let caught_exception_ref = Operand::Just(Identifier::CaughtException);
+                let caught_exception_ref = Operand::Just(Identifier::CaughtException(handler_pc));
                 let handler_frame =
                     frame.same_locals_1_stack_item_frame(Entry::Value(caught_exception_ref));
                 let exceptions = entries

--- a/src/ir/moka_instruction.rs
+++ b/src/ir/moka_instruction.rs
@@ -210,8 +210,8 @@ pub enum Identifier {
     /// A locally defined value.
     Local(LocalValue),
     /// The exception caught by a `catch` block.
-    #[display("%caught_exception")]
-    CaughtException,
+    #[display("%caught_exception@{_0}")]
+    CaughtException(ProgramCounter),
 }
 
 impl From<LocalValue> for Identifier {

--- a/src/jvm/code/pc.rs
+++ b/src/jvm/code/pc.rs
@@ -16,6 +16,7 @@ use std::{fmt::Debug, ops::Add};
 )]
 #[repr(transparent)]
 #[display("#{_0:04X}")]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ProgramCounter(u16);
 
 impl ProgramCounter {


### PR DESCRIPTION
Add the location of the exception handler to distinguish different caught exceptions.